### PR TITLE
Introduce better message passing between threads

### DIFF
--- a/PocoLithp/ELisp.cpp
+++ b/PocoLithp/ELisp.cpp
@@ -5,5 +5,8 @@
 namespace Elispidae {
 	void init_runtime() {
 		Threads::init_threads();
+		Stdlib::init_dictionary();
+		Stdlib::init_lists();
+		Stdlib::init_strings();
 	}
 }

--- a/PocoLithp/ELisp.hpp
+++ b/PocoLithp/ELisp.hpp
@@ -12,4 +12,10 @@ namespace Elispidae {
 	namespace Threads {
 		void init_threads();
 	}
+
+	namespace Stdlib {
+		void init_dictionary();
+		void init_lists();
+		void init_strings();
+	}
 }

--- a/PocoLithp/Elispidae.vcxproj
+++ b/PocoLithp/Elispidae.vcxproj
@@ -162,7 +162,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>READLINE_NG;POCO_STATIC ;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include;.</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -177,7 +177,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>READLINE_NG;POCO_STATIC ;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include;.</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -192,7 +192,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>READLINE_NG;POCO_STATIC ;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include;.</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -207,7 +207,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>READLINE_NG;POCO_STATIC ;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include;.</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -222,7 +222,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>READLINE_NG;POCO_STATIC ;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include;.</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -237,7 +237,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>READLINE_NG;POCO_STATIC ;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include;.</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -254,7 +254,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>READLINE_NG;POCO_STATIC ;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include;.</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
@@ -277,7 +277,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>READLINE_NG;POCO_STATIC ;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
-      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\contrib\poco\Foundation\include;..\contrib\linenoise-ng\include;..\contrib\Stackless\Stackless\include;.</AdditionalIncludeDirectories>
       <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
       <OmitFramePointers>true</OmitFramePointers>
@@ -301,12 +301,11 @@
     <ClInclude Include="PLint_stackless.hpp" />
     <ClInclude Include="PocoLithp.hpp" />
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="stdlib\stdafx.h" />
     <ClInclude Include="targetver.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ELisp.cpp" />
-    <ClCompile Include="ELthreads.cpp" />
-    <ClCompile Include="PLglobals.cpp" />
     <ClCompile Include="PLinterpreter.cpp" />
     <ClCompile Include="PLint_recursive.cpp" />
     <ClCompile Include="PLint_stackless.cpp" />
@@ -325,6 +324,11 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="stdlib\ELdictionary.cpp" />
+    <ClCompile Include="stdlib\ELlists.cpp" />
+    <ClCompile Include="stdlib\ELstrings.cpp" />
+    <ClCompile Include="stdlib\ELthreads.cpp" />
+    <ClCompile Include="stdlib\PLglobals.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\lib\init.lisp" />

--- a/PocoLithp/Elispidae.vcxproj
+++ b/PocoLithp/Elispidae.vcxproj
@@ -331,6 +331,7 @@
     <ClCompile Include="stdlib\PLglobals.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\lib\cosmos.lisp" />
     <None Include="..\lib\init.lisp" />
     <None Include="..\lib\lists.lisp" />
     <None Include="..\lib\misc.lisp" />

--- a/PocoLithp/Elispidae.vcxproj.filters
+++ b/PocoLithp/Elispidae.vcxproj.filters
@@ -134,5 +134,8 @@
     <None Include="..\samples\threading.lisp">
       <Filter>samples</Filter>
     </None>
+    <None Include="..\lib\cosmos.lisp">
+      <Filter>lib</Filter>
+    </None>
   </ItemGroup>
 </Project>

--- a/PocoLithp/Elispidae.vcxproj.filters
+++ b/PocoLithp/Elispidae.vcxproj.filters
@@ -19,6 +19,9 @@
     <Filter Include="lib">
       <UniqueIdentifier>{eda4fb66-7eb7-47f0-99b3-6e0e171a52fd}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source Files\stdlib">
+      <UniqueIdentifier>{2d940747-ff3c-4cba-8455-53371080dee6}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <Text Include="ReadMe.txt" />
@@ -45,6 +48,9 @@
     <ClInclude Include="ELisp.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="stdlib\stdafx.h">
+      <Filter>Source Files\stdlib</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="stdafx.cpp">
@@ -54,9 +60,6 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="PLtests.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="PLglobals.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="PLinterpreter.cpp">
@@ -77,11 +80,23 @@
     <ClCompile Include="PLint_stackless.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="ELthreads.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="ELisp.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="stdlib\ELstrings.cpp">
+      <Filter>Source Files\stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="stdlib\ELthreads.cpp">
+      <Filter>Source Files\stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="stdlib\PLglobals.cpp">
+      <Filter>Source Files\stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="stdlib\ELlists.cpp">
+      <Filter>Source Files\stdlib</Filter>
+    </ClCompile>
+    <ClCompile Include="stdlib\ELdictionary.cpp">
+      <Filter>Source Files\stdlib</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/PocoLithp/PLint_stackless.cpp
+++ b/PocoLithp/PLint_stackless.cpp
@@ -47,6 +47,7 @@ namespace PocoLithp {
 					case Procedure:
 						result = res;
 						if (was_macro) {
+							DEBUG("  executing macro result");
 							setExpression(result, impl);
 							return;
 						}

--- a/PocoLithp/PLint_stackless.cpp
+++ b/PocoLithp/PLint_stackless.cpp
@@ -473,13 +473,19 @@ namespace PocoLithp {
 				LithpThreadManager::impl_p impl(new LithpImplementation(ins, env));
 				return impl;
 			});
-			// execute multithreading until thread resolved
-			tm.runThreadToCompletion(thread, Multi);
-			// return frame result
-			LithpCell result(tm.getThread(thread).getResult());
-			// remove thread
-			tm.remove_thread(thread);
-			return result;
+			try {
+				// execute multithreading until thread resolved
+				tm.runThreadToCompletion(thread, Multi);
+				// return frame result
+				LithpCell result(tm.getThread(thread).getResult());
+				// remove thread
+				tm.remove_thread(thread);
+				return result;
+			} catch (...) {
+				// remove thread
+				tm.remove_thread(thread);
+				throw;
+			}
 		}
 	}
 

--- a/PocoLithp/PLint_stackless.cpp
+++ b/PocoLithp/PLint_stackless.cpp
@@ -472,23 +472,17 @@ namespace PocoLithp {
 				timeout = *it; ++it;
 			}
 
-			frame.result = sym_sleep;
-			if (frame.is_sleeping == false) {
-				frame.is_sleeping = true;
-				LithpThreadReference thread_ref(impl);
-				if (timeout == sym_infinity) {
-					LithpProcessMan.thread_sleep_forever(thread_ref);
-				} else {
-					ThreadTimeUnit duration = (ThreadTimeUnit)timeout.value.convert<UnsignedInteger>();
-					LithpProcessMan.thread_sleep_for(thread_ref, duration);
-				}
-				if (GetDEBUG()) std::cerr << "! sleeping" << std::endl;
-				return false;
+			LithpThreadReference thread_ref(impl);
+			if (timeout == sym_infinity) {
+				LithpProcessMan.thread_sleep_forever(thread_ref);
 			} else {
-				frame.is_sleeping = false;
-				if (GetDEBUG()) std::cerr << "! waking up" << std::endl;
-				return true;
+				ThreadTimeUnit duration = (ThreadTimeUnit)timeout.value.convert<UnsignedInteger>();
+				LithpProcessMan.thread_sleep_for(thread_ref, duration);
 			}
+			if (GetDEBUG()) std::cerr << "! sleeping" << std::endl;
+			frame.result = LithpCell(Atom, "sleeping");
+			// Don't move exp_it - it will be moved by implementation instead
+			return false;
 		}
 
 		bool LithpFrame::dispatchCall(const LithpImplementation &impl) {

--- a/PocoLithp/PLinterpreter.cpp
+++ b/PocoLithp/PLinterpreter.cpp
@@ -101,6 +101,8 @@ namespace PocoLithp {
 			return repre ? rawstr(exp.proc()) : "<Proc>";
 		else if (exp.tag == ProcExtended)
 			return repre ? rawstr(exp.proc_extended()) : "<ProcExtended>";
+		else if (exp.tag == ProcImplementation)
+			return repre ? rawstr(exp.proc_implementation()) : "<ProcImplementation>";
 		else if (exp.tag == Dict) {
 			std::string s("{");
 			const LithpDict &dict = exp.dict();

--- a/PocoLithp/PLinterpreter.cpp
+++ b/PocoLithp/PLinterpreter.cpp
@@ -164,6 +164,9 @@ namespace PocoLithp {
 				partialBuffer += line;
 			} catch (const std::exception &e) {
 				std::cerr << "ERROR " << e.what() << "\n";
+				// Clear buffer on error
+				line = "";
+				partialBuffer = "";
 			}
 		}
 

--- a/PocoLithp/PocoLithp.cpp
+++ b/PocoLithp/PocoLithp.cpp
@@ -4,7 +4,6 @@
 // TODO: Bignum support
 
 #include "stdafx.h"
-#include "ELisp.hpp"
 
 using namespace PocoLithp;
 

--- a/PocoLithp/PocoLithp.cpp
+++ b/PocoLithp/PocoLithp.cpp
@@ -89,16 +89,19 @@ int main(int argc, char *argv[])
 	}
 
 	// Run until all threads are finished
-#ifdef ELISP_STACKLES // FIXME
-	auto &tm = PocoLithp::Stackless::LithpThreadMan;
-	if (GetDEBUG())
-		std::cerr << "Waiting for " << tm.threadCount() << " threads to exit..." << std::endl;
-	while (tm.hasThreads())
-		tm.executeThreads();
+#ifdef ELISP_STACKLESS
+	if (Stackless::LithpProcessMan.hasThreads()) {
+		if (GetDEBUG())
+			std::cerr << "Waiting for " << Stackless::LithpProcessMan.threadCount() << " threads to exit..." << std::endl;
+		while (Stackless::LithpProcessMan.hasThreads())
+			Stackless::LithpProcessMan.executeThreads();
+	}
 #endif
 
 	if(GetTIMING())
 		std::cerr << "Total eval time: " << GetEvalTime() << "ms, parse time: " << parseTime << "ms\n";
+	if (GetDEBUG())
+		GETLINE("Press ENTER to quit>");
     return ERR_NOERROR;
 }
 

--- a/PocoLithp/PocoLithp.cpp
+++ b/PocoLithp/PocoLithp.cpp
@@ -4,6 +4,7 @@
 // TODO: Bignum support
 
 #include "stdafx.h"
+#include "PLint_stackless.hpp"
 
 using namespace PocoLithp;
 
@@ -11,6 +12,10 @@ const int ERR_NOERROR = 0;
 const int ERR_FILE = 1;
 const int ERR_SYNTAX = 2;
 const int ERR_EXCEPTION = 3;
+
+PocoLithp::LithpThreadReference::LithpThreadReference(const PocoLithp::Stackless::LithpImplementation &impl)
+	: thread_id(impl.thread_id), node_id(impl.node_id), cosmos_id(impl.cosmos_id) {
+}
 
 std::string stdin_getline(const std::string &prompt) {
 	std::string line;
@@ -84,7 +89,7 @@ int main(int argc, char *argv[])
 	}
 
 	// Run until all threads are finished
-#ifdef ELISP_STACKLESS
+#ifdef ELISP_STACKLES // FIXME
 	auto &tm = PocoLithp::Stackless::LithpThreadMan;
 	if (GetDEBUG())
 		std::cerr << "Waiting for " << tm.threadCount() << " threads to exit..." << std::endl;

--- a/PocoLithp/PocoLithp.hpp
+++ b/PocoLithp/PocoLithp.hpp
@@ -3,7 +3,7 @@
 #include "stdafx.h"
 #include <Stackless.hpp>		// Ugly hack
 
-#define ELISP_VERSION "0.82"
+#define ELISP_VERSION "0.83"
 
 // Undefine to use recursive emulator
 #define ELISP_STACKLESS

--- a/PocoLithp/PocoLithp.hpp
+++ b/PocoLithp/PocoLithp.hpp
@@ -3,7 +3,7 @@
 #include "stdafx.h"
 #include <Stackless.hpp>		// Ugly hack
 
-#define ELISP_VERSION "0.80"
+#define ELISP_VERSION "0.81"
 
 // Undefine to use recursive emulator
 #define ELISP_STACKLESS

--- a/PocoLithp/PocoLithp.hpp
+++ b/PocoLithp/PocoLithp.hpp
@@ -3,7 +3,7 @@
 #include "stdafx.h"
 #include <Stackless.hpp>		// Ugly hack
 
-#define ELISP_VERSION "0.83"
+#define ELISP_VERSION "0.85"
 
 // Undefine to use recursive emulator
 #define ELISP_STACKLESS
@@ -25,8 +25,31 @@
 #define STATS_DESC        "(no stats)"
 #endif
 
+// Architecture detection
+#ifdef _MSC_VER_
+#  if defined(_M_IX86)
+#    define ARCH "x86"
+#  elif defined(_M_X64) || defined(_M_AMD64)
+#    define ARCH "x64"
+#  else
+#    define ARCH "(unknown)"
+#  endif
+#elif __GNUC__
+#  if defined(__OR1K__)
+#    define ARCH "or1k"
+#  elif defined(__i386__)
+#    define ARCH "x86"
+#  elif defined(__x86_64)
+#    define ARCH "x64"
+#  else
+#    define ARCH "(unknown)"
+#  endif
+#else
+#  define ARCH "(misdetected)"
+#endif
+
 #define APP_NAME "Elispidae "
-#define ELISP_VERSION_INFO APP_NAME ELISP_VERSION STACKLESS_DESC
+#define ELISP_VERSION_INFO APP_NAME ELISP_VERSION STACKLESS_DESC " " ARCH
 
 namespace PocoLithp {
 	typedef Poco::Dynamic::Var PocoVar;

--- a/PocoLithp/PocoLithp.hpp
+++ b/PocoLithp/PocoLithp.hpp
@@ -3,7 +3,7 @@
 #include "stdafx.h"
 #include <Stackless.hpp>		// Ugly hack
 
-#define ELISP_VERSION "0.81"
+#define ELISP_VERSION "0.82"
 
 // Undefine to use recursive emulator
 #define ELISP_STACKLESS

--- a/PocoLithp/PocoLithp.hpp
+++ b/PocoLithp/PocoLithp.hpp
@@ -388,6 +388,18 @@ namespace PocoLithp {
 		const bool isString() const {
 			return (tag == Var && value.isString());
 		}
+		bool empty() const {
+			if (isList())
+				return list().empty();
+			else if (isString())
+				return value.size() == 0;
+			else if (tag == Dict)
+				return dict().empty();
+			else if (tag == Lambda || tag == Macro)
+				return list().empty();
+			// TODO: Too lenient?
+			return false;
+		}
 		size_t size() const {
 			if (isList())
 				return list().size();

--- a/PocoLithp/PocoLithp.hpp
+++ b/PocoLithp/PocoLithp.hpp
@@ -26,7 +26,7 @@
 #endif
 
 // Architecture detection
-#ifdef _MSC_VER_
+#ifdef _MSC_VER
 #  if defined(_M_IX86)
 #    define ARCH "x86"
 #  elif defined(_M_X64) || defined(_M_AMD64)

--- a/PocoLithp/stdafx.h
+++ b/PocoLithp/stdafx.h
@@ -39,3 +39,5 @@ std::string stdin_getline(const std::string &); bool stdin_eof();
 #endif
 
 #include "PocoLithp.hpp"
+#include "PLint_stackless.hpp"
+#include "ELisp.hpp"

--- a/PocoLithp/stdlib/ELdictionary.cpp
+++ b/PocoLithp/stdlib/ELdictionary.cpp
@@ -1,0 +1,36 @@
+/**
+ * Standard Library: Dictionary functions
+ */
+
+#include "stdafx.h"
+
+using namespace PocoLithp;
+using namespace PocoLithp::Stackless;
+
+// Get keys from dictionary
+LithpCell proc_keys(const LithpCells &c) {
+	if(c.size() != 1) throw InvalidArgumentException("Not enough parameters for keys(::dict)");
+	const LithpDict &dict = c[0].dict();
+	LithpCells keys;
+	for(auto it = dict.begin(); it != dict.end(); ++it)
+		keys.push_back(LithpCell(Atom, it->first));
+	return LithpCell(List, keys);
+}
+
+// Get values from dictionary
+LithpCell proc_values(const LithpCells &c) {
+	if(c.size() != 1) throw InvalidArgumentException("Not enough parameters for values(::dict)");
+	const LithpDict &dict = c[0].dict();
+	LithpCells values;
+	for(auto it = dict.begin(); it != dict.end(); ++it)
+		values.push_back(LithpCell(Var, it->second));
+	return LithpCell(List, values);
+}
+
+
+void Elispidae::Stdlib::init_dictionary() {
+	add_environment_runtime([](LithpEnvironment &env) {
+		env["keys"] = LithpCell(&proc_keys);
+		env["values"] = LithpCell(&proc_values);
+	});
+}

--- a/PocoLithp/stdlib/ELlists.cpp
+++ b/PocoLithp/stdlib/ELlists.cpp
@@ -1,0 +1,81 @@
+/**
+ * Standard Library: String functions
+ */
+
+#include "stdafx.h"
+
+using namespace PocoLithp;
+using namespace PocoLithp::Stackless;
+
+
+LithpCell proc_empty(const LithpCells &c) {
+	if(c.size() == 0) return LithpCell(Var, 0);
+	return c[0].empty() ? sym_true : sym_false;
+}
+
+LithpCell proc_length(const LithpCells &c) {
+	if(c.size() == 0) return LithpCell(Var, 0);
+	return LithpCell(Var, c[0].size());
+}
+LithpCell proc_nullp(const LithpCells &c) {
+	if(c.size() == 0) return sym_true;
+	return c[0].is_nullp() ? sym_true : sym_false;
+}
+LithpCell proc_head(const LithpCells &c) {
+	if(c.size() == 0) return sym_nil;
+	if(c[0].size() == 0) return sym_nil;
+	return c[0][0];
+}
+
+LithpCell proc_tail(const LithpCells &c)
+{
+	if (c.size() == 0)
+		return LithpCell(List, LithpCells());
+	LithpCells result = c[0].list();
+	if(result.size() == 0)
+		return LithpCell(List, LithpCells());
+	result.erase(result.begin());
+	return LithpCell(List, result);
+}
+
+LithpCell proc_append(const LithpCells &c)
+{
+	if (c.size() == 0)
+		return LithpCell(List, LithpCells());
+	else if(c.size() == 1)
+		return LithpCell(List, c[0].list());
+	LithpCells result = c[0].list();
+	const LithpCells &c1l = c[1].list();
+	for (LithpCells::const_iterator i = c1l.begin(); i != c1l.end(); ++i)
+		result.push_back(*i);
+	return LithpCell(List, result);
+}
+
+LithpCell proc_cons(const LithpCells &c)
+{
+	if (c.size() == 0)
+		return LithpCell(List, LithpCells());
+	else if(c.size() == 1)
+		return LithpCell(List, c[0].list());
+	LithpCells result;
+	const LithpCells &c1l = c[1].list();
+	result.push_back(c[0]);
+	for (LithpCells::const_iterator i = c1l.begin(); i != c1l.end(); ++i)
+		result.push_back(*i);
+	return LithpCell(List, result);
+}
+
+LithpCell proc_list(const LithpCells &c)
+{
+	return LithpCell(List, c);
+}
+
+void Elispidae::Stdlib::init_lists() {
+	add_environment_runtime([](LithpEnvironment &env) {
+		env["append"] = LithpCell(&proc_append);        env["head"] = LithpCell(&proc_head);
+		env["tail"] = LithpCell(&proc_tail);            env["cons"] = LithpCell(&proc_cons);
+		env["length"] = LithpCell(&proc_length);        env["list"] = LithpCell(&proc_list);
+		env["null?"] = LithpCell(&proc_nullp);
+		env["empty?"] = LithpCell(&proc_empty);
+	});
+}

--- a/PocoLithp/stdlib/ELstrings.cpp
+++ b/PocoLithp/stdlib/ELstrings.cpp
@@ -1,0 +1,57 @@
+/**
+ * Standard Library: String functions
+ */
+
+#include "stdafx.h"
+
+using namespace PocoLithp;
+using namespace PocoLithp::Stackless;
+
+// (asc String::str()) => AsciiCode::int()
+// -desc Returns ASCII code of first character, or nil if no string provided
+LithpCell proc_asc(const LithpCells &c) {
+	if (c.empty())
+		return sym_nil;
+	const LithpCell &cell = *c.begin();
+	const std::string str = cell.value.toString();
+	// TODO: won't work with unicide.
+	return LithpCell(Var, (UnsignedInteger)str[0]);
+}
+
+LithpCell proc_chr(const LithpCells &c) {
+	if (c.empty())
+		return sym_nil;
+	const LithpCell &cell = *c.begin();
+	// TODO: wont work with unicode.
+	char x = 1;
+	return LithpCell(Var, std::string(1, cell.value.convert<char>()));
+}
+
+// Explode a string into a list
+LithpCell proc_expl(const LithpCells &c) {
+	if(c.size() == 0) return LithpCell(List, LithpCells());
+	std::string str = c[0].str();
+	LithpCells list;
+	for (auto it = str.begin(); it != str.end(); ++it)
+		list.push_back(LithpCell(Var, std::string(1, *it)));
+	return LithpCell(List, list);
+}
+
+// Convert argument to string
+LithpCell proc_tostring(const LithpCells &c) {
+	bool repre = false;
+	if (c.size() == 0)
+		return LithpCell(Var, std::string(""));
+	if (c.size() == 2)
+		repre = c[1] == sym_true ? true : false;
+	return LithpCell(Var, to_string(c[0], true, repre));
+}
+
+void Elispidae::Stdlib::init_strings() {
+	add_environment_runtime([](LithpEnvironment &env) {
+		env["asc"] = LithpCell(&proc_asc);
+		env["chr"] = LithpCell(&proc_chr);
+		env["expl"] = LithpCell(&proc_expl);
+		env["str"] = env["tostring"] = LithpCell(&proc_tostring);
+	});
+}

--- a/PocoLithp/stdlib/ELthreads.cpp
+++ b/PocoLithp/stdlib/ELthreads.cpp
@@ -1,8 +1,5 @@
 #include "stdafx.h"
 
-#include "PLint_stackless.hpp"
-#include "ELisp.hpp"
-
 using namespace PocoLithp;
 using namespace PocoLithp::Stackless;
 

--- a/PocoLithp/stdlib/ELthreads.cpp
+++ b/PocoLithp/stdlib/ELthreads.cpp
@@ -1,26 +1,22 @@
 #include "stdafx.h"
+#include "PLint_stackless.hpp"
 
 using namespace PocoLithp;
 using namespace PocoLithp::Stackless;
 
-LithpThreadReference getCurrentThreadRef() {
-	// TODO: Could get lost
-	auto thread = LithpThreadMan.getCurrentThread();
-	return LithpThreadReference(thread->thread_id);
-}
-
 // Get thread reference to current running thread
-LithpCell proc_self(const LithpCells &c) {
-	return LithpCell(Thread, getCurrentThreadRef());
+LithpCell proc_self(const LithpCells &c, Env_p env, const LithpImplementation &impl) {
+	return LithpCell(Thread, LithpThreadReference(impl));
 }
 
 // Get a list of references to all threads
 LithpCell proc_threads(const LithpCells &c) {
 	LithpCells list;
-	auto threads = LithpThreadMan.getThreads();
+	return sym_nil; // FIXME
+	/*auto threads = LithpThreadMan.getThreads();
 	for (auto it = threads.cbegin(); it != threads.cend(); ++it)
 		list.push_back(LithpCell(Thread, LithpThreadReference(it->thread_id)));
-	return LithpCell(List, list);
+	return LithpCell(List, list);*/
 }
 
 // Send a message to a thread
@@ -35,9 +31,10 @@ LithpCell proc_send(const LithpCells &c) {
 	const LithpCell &threadref = *it; ++it;
 	if (threadref.tag != Thread)
 		throw InvalidArgumentException("(send: thread should be a threadref)");
+	return sym_nil; // FIXME
 	// Todo: lookup by thread reference
-	LithpThreadManager &man = LithpThreadMan;
-	return man.send(message, threadref.thread_ref()) ? sym_true : sym_false;
+	//LithpThreadManager &man = LithpThreadMan;
+	//return man.send(message, threadref.thread_ref()) ? sym_true : sym_false;
 }
 
 // Flush messages for a given thread and return as list
@@ -52,8 +49,9 @@ LithpCell proc_flush(const LithpCells &c) {
 	UnsignedInteger limit = 0, count = 0;
 	if (it != c.cend())
 		limit = it->value.convert<UnsignedInteger>();
+	return sym_nil; // FIXME
 	// Todo: lookup by thread reference
-	LithpThreadManager &man = LithpThreadMan;
+	/*LithpThreadManager &man = LithpThreadMan;
 	LithpCells result;
 	for(;;) {
 		LithpCell message;
@@ -66,7 +64,7 @@ LithpCell proc_flush(const LithpCells &c) {
 		if (limit != 0 && count == limit)
 			break;
 	}
-	return LithpCell(List, result);
+	return LithpCell(List, result);*/
 }
 
 // Spawn a new microthread.
@@ -79,6 +77,8 @@ LithpCell proc_spawn(const LithpCells &c, Env_p env) {
 	const LithpCell &lambda = *it; ++it;
 	// Get arguments (may be an empty list)
 	const LithpCells args(it, c.cend());
+	return sym_nil; // FIXME
+	/*
 	LithpThreadManager &tm = LithpThreadMan;
 	// Create thread
 	ThreadId thread = tm.start([&lambda, &args, env]() {
@@ -92,7 +92,7 @@ LithpCell proc_spawn(const LithpCells &c, Env_p env) {
 		return impl;
 	});
 	// Create thread reference
-	return LithpCell(Thread, LithpThreadReference(thread));
+	return LithpCell(Thread, LithpThreadReference(thread));*/
 }
 
 void Elispidae::Threads::init_threads() {

--- a/PocoLithp/stdlib/ELthreads.cpp
+++ b/PocoLithp/stdlib/ELthreads.cpp
@@ -1,5 +1,5 @@
 #include "stdafx.h"
-#include "PLint_stackless.hpp"
+#include "../PLint_stackless.hpp"
 
 using namespace PocoLithp;
 using namespace PocoLithp::Stackless;

--- a/PocoLithp/stdlib/ELthreads.cpp
+++ b/PocoLithp/stdlib/ELthreads.cpp
@@ -1,3 +1,4 @@
+#include <cstdlib>      // exit()
 #include "stdafx.h"
 #include "../PLint_stackless.hpp"
 
@@ -82,6 +83,19 @@ LithpCell proc_spawn(const LithpCells &c, Env_p env) {
 	return LithpCell(Thread, thread);
 }
 
+// Force an exit and return an exit code from the application.
+// (exit Code::integer(Default=1))
+LithpCell proc_exit(const LithpCells &c) {
+	int status = 1;
+	auto it = c.cbegin();
+	if (it != c.cend())
+		status = it->value.convert<int>();
+	if (GetDEBUG())
+		GETLINE("Press ENTER to quit>");
+	LithpProcessMan.force_exit();
+	exit(status);
+}
+
 void Elispidae::Threads::init_threads() {
 	add_environment_runtime([](LithpEnvironment &env) {
 		env["self"] = LithpCell(&proc_self);
@@ -89,5 +103,6 @@ void Elispidae::Threads::init_threads() {
 		env["send"] = LithpCell(&proc_send);
 		env["flush"] = LithpCell(&proc_flush);
 		env["spawn"] = LithpCell(&proc_spawn);
+		env["exit"] = LithpCell(&proc_exit);
 	});
 }

--- a/PocoLithp/stdlib/PLglobals.cpp
+++ b/PocoLithp/stdlib/PLglobals.cpp
@@ -28,6 +28,7 @@ namespace PocoLithp {
 	const LithpCell sym_macro(Atom, "macro");
 	const LithpCell sym_begin(Atom, "begin");
 	const LithpCell sym_receive(Atom, "receive");
+	const LithpCell sym_sleep(Atom, "sleep");
 	const LithpCell sym_after(Atom, "after");
 	const LithpCell sym_infinity(Atom, "infinity");
 
@@ -260,25 +261,6 @@ namespace PocoLithp {
 		return repl(prompt, env);
 	}
 
-	// Call the eval function in the current environment with the tokenized
-	// arguments.
-	// It is named _eval since implementing a native  eval function is
-	// a goal of this interpreter. It would allow extending the
-	// interpreter in classic Lisp ways.
-	LithpCell proc__eval(const LithpCells &c, Env_p env) {
-		if(c.size() == 0) return sym_nil;
-		return eval(c[0], env);
-	}
-
-	// Call the eval function in the topmost environment with the tokenized
-	// arguments.
-	// This means any definitions will be defined in the topmost environment.
-	// TODO: Should a define-all or export be implemented instead?
-	LithpCell proc__eval_ctx(const LithpCells &c, Env_p env) {
-		if(c.size() == 0) return sym_nil;
-		return eval(c[0], env->getTopmost(env));
-	}
-
 	// Tokenize the given string
 	LithpCell proc__tokenize(const LithpCells &c) {
 		if(c.size() == 0) return sym_nil;
@@ -351,8 +333,6 @@ namespace PocoLithp {
 		env["getline"] = LithpCell(&proc_getline);
 		// Stackless interpreter defines this in ELthreads.cpp
 		env["repl"] = LithpCell(&proc_repl);
-		env["_eval"] = LithpCell(&proc__eval);
-		env["_eval_ctx"] = LithpCell(&proc__eval_ctx);
 		env["_tokenize"] = LithpCell(&proc__tokenize);
 
 		// File IO

--- a/PocoLithp/stdlib/PLglobals.cpp
+++ b/PocoLithp/stdlib/PLglobals.cpp
@@ -328,6 +328,10 @@ namespace PocoLithp {
 		return LithpCell(Var, count);
 	}
 
+	LithpCell proc_arch(const LithpCells &args) {
+		return LithpCell(Atom, ARCH);
+	}
+
 	void add_environment_runtime(add_environment_proc p) {
 		environment_procs.push_back(p);
 	}
@@ -361,6 +365,9 @@ namespace PocoLithp {
 
 		// Export functions
 		env["export"] = LithpCell(&proc_export);
+
+		// Architecture/build information
+		env["arch"] = LithpCell(&proc_arch);
 		
 		// Add any other procs
 		for (auto it = environment_procs.begin(); it != environment_procs.end(); ++it)

--- a/PocoLithp/stdlib/PLglobals.cpp
+++ b/PocoLithp/stdlib/PLglobals.cpp
@@ -176,73 +176,6 @@ namespace PocoLithp {
 		return booleanCell(!(c[0] == sym_true));
 	}
 
-	LithpCell proc_length(const LithpCells &c) {
-		if(c.size() == 0) return LithpCell(Var, 0);
-		return LithpCell(Var, c[0].size());
-	}
-	LithpCell proc_nullp(const LithpCells &c) {
-		if(c.size() == 0) return sym_true;
-		return c[0].is_nullp() ? sym_true : sym_false;
-	}
-	LithpCell proc_head(const LithpCells &c) {
-		if(c.size() == 0) return sym_nil;
-		if(c[0].size() == 0) return sym_nil;
-		return c[0][0];
-	}
-
-	LithpCell proc_tail(const LithpCells &c)
-	{
-		if (c.size() == 0)
-			return LithpCell(List, LithpCells());
-		LithpCells result = c[0].list();
-		if(result.size() == 0)
-			return LithpCell(List, LithpCells());
-		result.erase(result.begin());
-		return LithpCell(List, result);
-	}
-
-	LithpCell proc_append(const LithpCells &c)
-	{
-		if (c.size() == 0)
-			return LithpCell(List, LithpCells());
-		else if(c.size() == 1)
-			return LithpCell(List, c[0].list());
-		LithpCells result = c[0].list();
-		const LithpCells &c1l = c[1].list();
-		for (LithpCells::const_iterator i = c1l.begin(); i != c1l.end(); ++i)
-			result.push_back(*i);
-		return LithpCell(List, result);
-	}
-
-	LithpCell proc_cons(const LithpCells &c)
-	{
-		if (c.size() == 0)
-			return LithpCell(List, LithpCells());
-		else if(c.size() == 1)
-			return LithpCell(List, c[0].list());
-		LithpCells result;
-		const LithpCells &c1l = c[1].list();
-		result.push_back(c[0]);
-		for (LithpCells::const_iterator i = c1l.begin(); i != c1l.end(); ++i)
-			result.push_back(*i);
-		return LithpCell(List, result);
-	}
-
-	LithpCell proc_list(const LithpCells &c)
-	{
-		return LithpCell(List, c);
-	}
-
-	// Explode a string into a list
-	LithpCell proc_expl(const LithpCells &c) {
-		if(c.size() == 0) return LithpCell(List, LithpCells());
-		std::string str = c[0].str();
-		LithpCells list;
-		for (auto it = str.begin(); it != str.end(); ++it)
-			list.push_back(LithpCell(Var, std::string(1, *it)));
-		return LithpCell(List, list);
-	}
-
 	// Get or set debug state
 	LithpCell proc_debug(const LithpCells &c)
 	{
@@ -281,26 +214,6 @@ namespace PocoLithp {
 	// Get environment values
 	LithpCell proc_env(const LithpCells &c, Env_p env) {
 		return LithpCell(List, env->getCompleteEnv());
-	}
-
-	// Get keys from dictionary
-	LithpCell proc_keys(const LithpCells &c) {
-		if(c.size() != 1) throw InvalidArgumentException("Not enough parameters for keys(::dict)");
-		const LithpDict &dict = c[0].dict();
-		LithpCells keys;
-		for(auto it = dict.begin(); it != dict.end(); ++it)
-			keys.push_back(LithpCell(Atom, it->first));
-		return LithpCell(List, keys);
-	}
-
-	// Get values from dictionary
-	LithpCell proc_values(const LithpCells &c) {
-		if(c.size() != 1) throw InvalidArgumentException("Not enough parameters for values(::dict)");
-		const LithpDict &dict = c[0].dict();
-		LithpCells values;
-		for(auto it = dict.begin(); it != dict.end(); ++it)
-			values.push_back(LithpCell(Var, it->second));
-		return LithpCell(List, values);
 	}
 
 	// Get current eval depth
@@ -367,22 +280,10 @@ namespace PocoLithp {
 	}
 
 	// Tokenize the given string
-	LithpCell proc__tokensize(const LithpCells &c) {
+	LithpCell proc__tokenize(const LithpCells &c) {
 		if(c.size() == 0) return sym_nil;
 		std::list<std::string> tokens = tokenize(c[0].str());
 		return read_from(tokens);
-	}
-
-	/** String procedures */
-
-	// Convert argument to string
-	LithpCell proc_tostring(const LithpCells &c) {
-		bool repre = false;
-		if (c.size() == 0)
-			return LithpCell(Var, std::string(""));
-		if (c.size() == 2)
-			repre = c[1] == sym_true ? true : false;
-		return LithpCell(Var, to_string(c[0], true, repre));
 	}
 
 	/** Variable procedures */
@@ -433,10 +334,6 @@ namespace PocoLithp {
 	// define the bare minimum set of primitives necessary to pass the unit tests
 	void add_globals(LithpEnvironment &env)
 	{
-		env["append"] = LithpCell(&proc_append);        env["head"] = LithpCell(&proc_head);
-		env["tail"] = LithpCell(&proc_tail);            env["cons"] = LithpCell(&proc_cons);
-		env["length"] = LithpCell(&proc_length);        env["list"] = LithpCell(&proc_list);
-		env["null?"] = LithpCell(&proc_nullp);
 		env["+"] = LithpCell(&proc_add);                env["-"] = LithpCell(&proc_sub);
 		env["*"] = LithpCell(&proc_mul);                env["/"] = LithpCell(&proc_div);
 		env[">"] = LithpCell(&proc_greater);            env["<"] = LithpCell(&proc_less);
@@ -456,23 +353,13 @@ namespace PocoLithp {
 		env["repl"] = LithpCell(&proc_repl);
 		env["_eval"] = LithpCell(&proc__eval);
 		env["_eval_ctx"] = LithpCell(&proc__eval_ctx);
-		env["_tokenize"] = LithpCell(&proc__tokensize);
+		env["_tokenize"] = LithpCell(&proc__tokenize);
 
 		// File IO
-		
-		// String
-		env["str"] = env["tostring"] = LithpCell(&proc_tostring);
 
 		// Variable information
 		env["tag"] = LithpCell(&proc_tag);
 		
-		// String functions
-		env["expl"] = LithpCell(&proc_expl);
-
-		// Dict functions
-		env["keys"] = LithpCell(&proc_keys);
-		env["values"] = LithpCell(&proc_values);
-
 		// Add any other procs
 		for (auto it = environment_procs.begin(); it != environment_procs.end(); ++it)
 			(*it)(env);

--- a/PocoLithp/stdlib/stdafx.h
+++ b/PocoLithp/stdlib/stdafx.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// TODO: This ugly hack is needed to resolve issues in Visual Studio.
+// Intellisense says that project symbols are missing, but compiles fine.
+// https://stackoverflow.com/questions/31943634/visual-studio-2015-intellisense-errors-but-solution-compiles
+
+#include "../stdafx.h"

--- a/README.md
+++ b/README.md
@@ -111,20 +111,20 @@ How?
 Status
 ------
 
-**Version: 0.80**
+**Version: 0.85**
 
-**Language compatibility level:** Lisp-ish, with tail-call-optimization and macros.
+**Language compatibility level:** Lisp-ish, with macros.
 
     Mainly Lisp-like syntax, mixed with Lithp (Variables are introduced, `#` is synonym for `lambda`).
 
-	Microthreading and message passing included.
+	Microthreading, message passing, and scheduling is working.
+
+	Tail-call optimization is presently not working.
 
 Building
 ========
 
 * Requires Visual Studio 2015 or G++ 4.9.1 or higher.
-
-* Coming soon: CMake support
 
 Building (Visual Studio)
 ------------------------
@@ -185,6 +185,10 @@ Two methods are available:
 
 Notable Milestones
 ------------------
+
+* Completely rewrote microthread scheduling and message passing.
+
+* Fixed issue with REPL getting stuck in endless error loop.
 
 * Project renamed from PocoLithp to Elispidae.
 

--- a/lib/init.lisp
+++ b/lib/init.lisp
@@ -5,6 +5,10 @@
 
 	(define DefaultLibraries (list lists numeric string misc cosmos))
 
+	;; Implement _eval_ctx as a macro
+	(define _eval_ctx (macro Exp Exp))
+	(define _eval (macro Exp Exp))
+
 	;; (timing true)
 	;; (debug true)
 	(define __module__ (macro () init))

--- a/lib/lists.lisp
+++ b/lib/lists.lisp
@@ -51,6 +51,7 @@
 			(+ Acc (if (= list (tag Element)) (flatten Element) (list Element)))
 		)))
 	)))
-	(print (flatten (list 1 2 3 (list 4 5 6) 7 8)))
+
+	(export foldl each map filter member combine zip take drop mid riff-shuffle flatten)
 )
 

--- a/lib/misc.lisp
+++ b/lib/misc.lisp
@@ -41,4 +41,5 @@
 		))
 	)))
 
+	(export compose repeat lookup ifDefined tuple envstr)
 )

--- a/lib/numeric.lisp
+++ b/lib/numeric.lisp
@@ -17,4 +17,6 @@
 	(define fac2 (# (N A) (begin
 		(if (<= N 0) A (fac2 (- N 1) (* N A)))
 	)))
+
+	(export % abs sum prod fac)
 )

--- a/lib/require.lisp
+++ b/lib/require.lisp
@@ -20,4 +20,6 @@
 			)
 		)
 	)))
+
+	(export require)
 )

--- a/lib/string.lisp
+++ b/lib/string.lisp
@@ -2,4 +2,6 @@
 	(define __module__ (macro () string))
 	;; Reverse of expl
 	(define unexpl (# (List) (foldl List "" (# (Char Acc) (+ Acc Char)))))
+
+	(export unexpl)
 )

--- a/nbproject/Makefile-Debug.mk
+++ b/nbproject/Makefile-Debug.mk
@@ -36,8 +36,6 @@ OBJECTDIR=${CND_BUILDDIR}/${CND_CONF}/${CND_PLATFORM}
 # Object Files
 OBJECTFILES= \
 	${OBJECTDIR}/PocoLithp/ELisp.o \
-	${OBJECTDIR}/PocoLithp/ELthreads.o \
-	${OBJECTDIR}/PocoLithp/PLglobals.o \
 	${OBJECTDIR}/PocoLithp/PLint_recursive.o \
 	${OBJECTDIR}/PocoLithp/PLint_stackless.o \
 	${OBJECTDIR}/PocoLithp/PLinterpreter.o \
@@ -47,6 +45,11 @@ OBJECTFILES= \
 	${OBJECTDIR}/PocoLithp/PLtypes.o \
 	${OBJECTDIR}/PocoLithp/PocoLithp.o \
 	${OBJECTDIR}/PocoLithp/stdafx.o \
+	${OBJECTDIR}/PocoLithp/stdlib/ELdictionary.o \
+	${OBJECTDIR}/PocoLithp/stdlib/ELlists.o \
+	${OBJECTDIR}/PocoLithp/stdlib/ELstrings.o \
+	${OBJECTDIR}/PocoLithp/stdlib/ELthreads.o \
+	${OBJECTDIR}/PocoLithp/stdlib/PLglobals.o \
 	${OBJECTDIR}/contrib/linenoise-ng/src/ConvertUTF.o \
 	${OBJECTDIR}/contrib/linenoise-ng/src/linenoise.o \
 	${OBJECTDIR}/contrib/linenoise-ng/src/wcwidth.o \
@@ -140,16 +143,6 @@ ${OBJECTDIR}/PocoLithp/ELisp.o: PocoLithp/ELisp.cpp
 	${RM} "$@.d"
 	$(COMPILE.cc) -g -DREADLINE_NG -D_DEBUG -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/ELisp.o PocoLithp/ELisp.cpp
 
-${OBJECTDIR}/PocoLithp/ELthreads.o: PocoLithp/ELthreads.cpp
-	${MKDIR} -p ${OBJECTDIR}/PocoLithp
-	${RM} "$@.d"
-	$(COMPILE.cc) -g -DREADLINE_NG -D_DEBUG -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/ELthreads.o PocoLithp/ELthreads.cpp
-
-${OBJECTDIR}/PocoLithp/PLglobals.o: PocoLithp/PLglobals.cpp
-	${MKDIR} -p ${OBJECTDIR}/PocoLithp
-	${RM} "$@.d"
-	$(COMPILE.cc) -g -DREADLINE_NG -D_DEBUG -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLglobals.o PocoLithp/PLglobals.cpp
-
 ${OBJECTDIR}/PocoLithp/PLint_recursive.o: PocoLithp/PLint_recursive.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
@@ -194,6 +187,31 @@ ${OBJECTDIR}/PocoLithp/stdafx.o: PocoLithp/stdafx.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
 	$(COMPILE.cc) -g -DREADLINE_NG -D_DEBUG -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdafx.o PocoLithp/stdafx.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/ELdictionary.o: PocoLithp/stdlib/ELdictionary.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -g -DREADLINE_NG -D_DEBUG -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/ELdictionary.o PocoLithp/stdlib/ELdictionary.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/ELlists.o: PocoLithp/stdlib/ELlists.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -g -DREADLINE_NG -D_DEBUG -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/ELlists.o PocoLithp/stdlib/ELlists.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/ELstrings.o: PocoLithp/stdlib/ELstrings.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -g -DREADLINE_NG -D_DEBUG -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/ELstrings.o PocoLithp/stdlib/ELstrings.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/ELthreads.o: PocoLithp/stdlib/ELthreads.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -g -DREADLINE_NG -D_DEBUG -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/ELthreads.o PocoLithp/stdlib/ELthreads.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/PLglobals.o: PocoLithp/stdlib/PLglobals.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -g -DREADLINE_NG -D_DEBUG -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/PLglobals.o PocoLithp/stdlib/PLglobals.cpp
 
 ${OBJECTDIR}/contrib/linenoise-ng/src/ConvertUTF.o: contrib/linenoise-ng/src/ConvertUTF.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/linenoise-ng/src

--- a/nbproject/Makefile-Release.mk
+++ b/nbproject/Makefile-Release.mk
@@ -36,8 +36,6 @@ OBJECTDIR=${CND_BUILDDIR}/${CND_CONF}/${CND_PLATFORM}
 # Object Files
 OBJECTFILES= \
 	${OBJECTDIR}/PocoLithp/ELisp.o \
-	${OBJECTDIR}/PocoLithp/ELthreads.o \
-	${OBJECTDIR}/PocoLithp/PLglobals.o \
 	${OBJECTDIR}/PocoLithp/PLint_recursive.o \
 	${OBJECTDIR}/PocoLithp/PLint_stackless.o \
 	${OBJECTDIR}/PocoLithp/PLinterpreter.o \
@@ -47,6 +45,11 @@ OBJECTFILES= \
 	${OBJECTDIR}/PocoLithp/PLtypes.o \
 	${OBJECTDIR}/PocoLithp/PocoLithp.o \
 	${OBJECTDIR}/PocoLithp/stdafx.o \
+	${OBJECTDIR}/PocoLithp/stdlib/ELdictionary.o \
+	${OBJECTDIR}/PocoLithp/stdlib/ELlists.o \
+	${OBJECTDIR}/PocoLithp/stdlib/ELstrings.o \
+	${OBJECTDIR}/PocoLithp/stdlib/ELthreads.o \
+	${OBJECTDIR}/PocoLithp/stdlib/PLglobals.o \
 	${OBJECTDIR}/contrib/linenoise-ng/src/ConvertUTF.o \
 	${OBJECTDIR}/contrib/linenoise-ng/src/linenoise.o \
 	${OBJECTDIR}/contrib/linenoise-ng/src/wcwidth.o \
@@ -138,267 +141,282 @@ bin/elisp: ${OBJECTFILES}
 ${OBJECTDIR}/PocoLithp/ELisp.o: PocoLithp/ELisp.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/ELisp.o PocoLithp/ELisp.cpp
-
-${OBJECTDIR}/PocoLithp/ELthreads.o: PocoLithp/ELthreads.cpp
-	${MKDIR} -p ${OBJECTDIR}/PocoLithp
-	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/ELthreads.o PocoLithp/ELthreads.cpp
-
-${OBJECTDIR}/PocoLithp/PLglobals.o: PocoLithp/PLglobals.cpp
-	${MKDIR} -p ${OBJECTDIR}/PocoLithp
-	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLglobals.o PocoLithp/PLglobals.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/ELisp.o PocoLithp/ELisp.cpp
 
 ${OBJECTDIR}/PocoLithp/PLint_recursive.o: PocoLithp/PLint_recursive.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLint_recursive.o PocoLithp/PLint_recursive.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLint_recursive.o PocoLithp/PLint_recursive.cpp
 
 ${OBJECTDIR}/PocoLithp/PLint_stackless.o: PocoLithp/PLint_stackless.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLint_stackless.o PocoLithp/PLint_stackless.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLint_stackless.o PocoLithp/PLint_stackless.cpp
 
 ${OBJECTDIR}/PocoLithp/PLinterpreter.o: PocoLithp/PLinterpreter.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLinterpreter.o PocoLithp/PLinterpreter.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLinterpreter.o PocoLithp/PLinterpreter.cpp
 
 ${OBJECTDIR}/PocoLithp/PLparser.o: PocoLithp/PLparser.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLparser.o PocoLithp/PLparser.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLparser.o PocoLithp/PLparser.cpp
 
 ${OBJECTDIR}/PocoLithp/PLruntime.o: PocoLithp/PLruntime.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLruntime.o PocoLithp/PLruntime.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLruntime.o PocoLithp/PLruntime.cpp
 
 ${OBJECTDIR}/PocoLithp/PLtests.o: PocoLithp/PLtests.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLtests.o PocoLithp/PLtests.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLtests.o PocoLithp/PLtests.cpp
 
 ${OBJECTDIR}/PocoLithp/PLtypes.o: PocoLithp/PLtypes.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLtypes.o PocoLithp/PLtypes.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PLtypes.o PocoLithp/PLtypes.cpp
 
 ${OBJECTDIR}/PocoLithp/PocoLithp.o: PocoLithp/PocoLithp.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PocoLithp.o PocoLithp/PocoLithp.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/PocoLithp.o PocoLithp/PocoLithp.cpp
 
 ${OBJECTDIR}/PocoLithp/stdafx.o: PocoLithp/stdafx.cpp
 	${MKDIR} -p ${OBJECTDIR}/PocoLithp
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdafx.o PocoLithp/stdafx.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdafx.o PocoLithp/stdafx.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/ELdictionary.o: PocoLithp/stdlib/ELdictionary.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/ELdictionary.o PocoLithp/stdlib/ELdictionary.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/ELlists.o: PocoLithp/stdlib/ELlists.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/ELlists.o PocoLithp/stdlib/ELlists.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/ELstrings.o: PocoLithp/stdlib/ELstrings.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/ELstrings.o PocoLithp/stdlib/ELstrings.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/ELthreads.o: PocoLithp/stdlib/ELthreads.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/ELthreads.o PocoLithp/stdlib/ELthreads.cpp
+
+${OBJECTDIR}/PocoLithp/stdlib/PLglobals.o: PocoLithp/stdlib/PLglobals.cpp
+	${MKDIR} -p ${OBJECTDIR}/PocoLithp/stdlib
+	${RM} "$@.d"
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/PocoLithp/stdlib/PLglobals.o PocoLithp/stdlib/PLglobals.cpp
 
 ${OBJECTDIR}/contrib/linenoise-ng/src/ConvertUTF.o: contrib/linenoise-ng/src/ConvertUTF.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/linenoise-ng/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/linenoise-ng/src/ConvertUTF.o contrib/linenoise-ng/src/ConvertUTF.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/linenoise-ng/src/ConvertUTF.o contrib/linenoise-ng/src/ConvertUTF.cpp
 
 ${OBJECTDIR}/contrib/linenoise-ng/src/linenoise.o: contrib/linenoise-ng/src/linenoise.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/linenoise-ng/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/linenoise-ng/src/linenoise.o contrib/linenoise-ng/src/linenoise.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/linenoise-ng/src/linenoise.o contrib/linenoise-ng/src/linenoise.cpp
 
 ${OBJECTDIR}/contrib/linenoise-ng/src/wcwidth.o: contrib/linenoise-ng/src/wcwidth.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/linenoise-ng/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/linenoise-ng/src/wcwidth.o contrib/linenoise-ng/src/wcwidth.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/linenoise-ng/src/wcwidth.o contrib/linenoise-ng/src/wcwidth.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/ASCIIEncoding.o: contrib/poco/Foundation/src/ASCIIEncoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/ASCIIEncoding.o contrib/poco/Foundation/src/ASCIIEncoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/ASCIIEncoding.o contrib/poco/Foundation/src/ASCIIEncoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Ascii.o: contrib/poco/Foundation/src/Ascii.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Ascii.o contrib/poco/Foundation/src/Ascii.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Ascii.o contrib/poco/Foundation/src/Ascii.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/AtomicCounter.o: contrib/poco/Foundation/src/AtomicCounter.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/AtomicCounter.o contrib/poco/Foundation/src/AtomicCounter.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/AtomicCounter.o contrib/poco/Foundation/src/AtomicCounter.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Bugcheck.o: contrib/poco/Foundation/src/Bugcheck.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Bugcheck.o contrib/poco/Foundation/src/Bugcheck.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Bugcheck.o contrib/poco/Foundation/src/Bugcheck.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/DateTime.o: contrib/poco/Foundation/src/DateTime.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/DateTime.o contrib/poco/Foundation/src/DateTime.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/DateTime.o contrib/poco/Foundation/src/DateTime.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/DateTimeFormat.o: contrib/poco/Foundation/src/DateTimeFormat.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/DateTimeFormat.o contrib/poco/Foundation/src/DateTimeFormat.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/DateTimeFormat.o contrib/poco/Foundation/src/DateTimeFormat.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/DateTimeParser.o: contrib/poco/Foundation/src/DateTimeParser.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/DateTimeParser.o contrib/poco/Foundation/src/DateTimeParser.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/DateTimeParser.o contrib/poco/Foundation/src/DateTimeParser.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Debugger.o: contrib/poco/Foundation/src/Debugger.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Debugger.o contrib/poco/Foundation/src/Debugger.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Debugger.o contrib/poco/Foundation/src/Debugger.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Exception.o: contrib/poco/Foundation/src/Exception.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Exception.o contrib/poco/Foundation/src/Exception.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Exception.o contrib/poco/Foundation/src/Exception.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Format.o: contrib/poco/Foundation/src/Format.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Format.o contrib/poco/Foundation/src/Format.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Format.o contrib/poco/Foundation/src/Format.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Latin1Encoding.o: contrib/poco/Foundation/src/Latin1Encoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Latin1Encoding.o contrib/poco/Foundation/src/Latin1Encoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Latin1Encoding.o contrib/poco/Foundation/src/Latin1Encoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Latin2Encoding.o: contrib/poco/Foundation/src/Latin2Encoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Latin2Encoding.o contrib/poco/Foundation/src/Latin2Encoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Latin2Encoding.o contrib/poco/Foundation/src/Latin2Encoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Latin9Encoding.o: contrib/poco/Foundation/src/Latin9Encoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Latin9Encoding.o contrib/poco/Foundation/src/Latin9Encoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Latin9Encoding.o contrib/poco/Foundation/src/Latin9Encoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/LocalDateTime.o: contrib/poco/Foundation/src/LocalDateTime.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/LocalDateTime.o contrib/poco/Foundation/src/LocalDateTime.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/LocalDateTime.o contrib/poco/Foundation/src/LocalDateTime.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Mutex.o: contrib/poco/Foundation/src/Mutex.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Mutex.o contrib/poco/Foundation/src/Mutex.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Mutex.o contrib/poco/Foundation/src/Mutex.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/NumberFormatter.o: contrib/poco/Foundation/src/NumberFormatter.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/NumberFormatter.o contrib/poco/Foundation/src/NumberFormatter.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/NumberFormatter.o contrib/poco/Foundation/src/NumberFormatter.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/NumberParser.o: contrib/poco/Foundation/src/NumberParser.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/NumberParser.o contrib/poco/Foundation/src/NumberParser.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/NumberParser.o contrib/poco/Foundation/src/NumberParser.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/NumericString.o: contrib/poco/Foundation/src/NumericString.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/NumericString.o contrib/poco/Foundation/src/NumericString.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/NumericString.o contrib/poco/Foundation/src/NumericString.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/RWLock.o: contrib/poco/Foundation/src/RWLock.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/RWLock.o contrib/poco/Foundation/src/RWLock.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/RWLock.o contrib/poco/Foundation/src/RWLock.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/RefCountedObject.o: contrib/poco/Foundation/src/RefCountedObject.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/RefCountedObject.o contrib/poco/Foundation/src/RefCountedObject.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/RefCountedObject.o contrib/poco/Foundation/src/RefCountedObject.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/TextConverter.o: contrib/poco/Foundation/src/TextConverter.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/TextConverter.o contrib/poco/Foundation/src/TextConverter.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/TextConverter.o contrib/poco/Foundation/src/TextConverter.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/TextEncoding.o: contrib/poco/Foundation/src/TextEncoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/TextEncoding.o contrib/poco/Foundation/src/TextEncoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/TextEncoding.o contrib/poco/Foundation/src/TextEncoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/TextIterator.o: contrib/poco/Foundation/src/TextIterator.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/TextIterator.o contrib/poco/Foundation/src/TextIterator.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/TextIterator.o contrib/poco/Foundation/src/TextIterator.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Timespan.o: contrib/poco/Foundation/src/Timespan.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Timespan.o contrib/poco/Foundation/src/Timespan.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Timespan.o contrib/poco/Foundation/src/Timespan.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Timestamp.o: contrib/poco/Foundation/src/Timestamp.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Timestamp.o contrib/poco/Foundation/src/Timestamp.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Timestamp.o contrib/poco/Foundation/src/Timestamp.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Timezone.o: contrib/poco/Foundation/src/Timezone.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Timezone.o contrib/poco/Foundation/src/Timezone.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Timezone.o contrib/poco/Foundation/src/Timezone.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/UTF16Encoding.o: contrib/poco/Foundation/src/UTF16Encoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UTF16Encoding.o contrib/poco/Foundation/src/UTF16Encoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UTF16Encoding.o contrib/poco/Foundation/src/UTF16Encoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/UTF32Encoding.o: contrib/poco/Foundation/src/UTF32Encoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UTF32Encoding.o contrib/poco/Foundation/src/UTF32Encoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UTF32Encoding.o contrib/poco/Foundation/src/UTF32Encoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/UTF8Encoding.o: contrib/poco/Foundation/src/UTF8Encoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UTF8Encoding.o contrib/poco/Foundation/src/UTF8Encoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UTF8Encoding.o contrib/poco/Foundation/src/UTF8Encoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/UTF8String.o: contrib/poco/Foundation/src/UTF8String.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UTF8String.o contrib/poco/Foundation/src/UTF8String.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UTF8String.o contrib/poco/Foundation/src/UTF8String.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Unicode.o: contrib/poco/Foundation/src/Unicode.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Unicode.o contrib/poco/Foundation/src/Unicode.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Unicode.o contrib/poco/Foundation/src/Unicode.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/UnicodeConverter.o: contrib/poco/Foundation/src/UnicodeConverter.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UnicodeConverter.o contrib/poco/Foundation/src/UnicodeConverter.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/UnicodeConverter.o contrib/poco/Foundation/src/UnicodeConverter.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Var.o: contrib/poco/Foundation/src/Var.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Var.o contrib/poco/Foundation/src/Var.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Var.o contrib/poco/Foundation/src/Var.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/VarHolder.o: contrib/poco/Foundation/src/VarHolder.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/VarHolder.o contrib/poco/Foundation/src/VarHolder.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/VarHolder.o contrib/poco/Foundation/src/VarHolder.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/VarIterator.o: contrib/poco/Foundation/src/VarIterator.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/VarIterator.o contrib/poco/Foundation/src/VarIterator.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/VarIterator.o contrib/poco/Foundation/src/VarIterator.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Windows1250Encoding.o: contrib/poco/Foundation/src/Windows1250Encoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Windows1250Encoding.o contrib/poco/Foundation/src/Windows1250Encoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Windows1250Encoding.o contrib/poco/Foundation/src/Windows1250Encoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Windows1251Encoding.o: contrib/poco/Foundation/src/Windows1251Encoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Windows1251Encoding.o contrib/poco/Foundation/src/Windows1251Encoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Windows1251Encoding.o contrib/poco/Foundation/src/Windows1251Encoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/Windows1252Encoding.o: contrib/poco/Foundation/src/Windows1252Encoding.cpp
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src
 	${RM} "$@.d"
-	$(COMPILE.cc) -flto -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Windows1252Encoding.o contrib/poco/Foundation/src/Windows1252Encoding.cpp
+	$(COMPILE.cc) -O3 -s -DREADLINE_NG -D_RELEASE -Icontrib/poco/Foundation/include -Icontrib/linenoise-ng/include -Icontrib/Stackless/Stackless/include -std=c++14 -MMD -MP -MF "$@.d" -o ${OBJECTDIR}/contrib/poco/Foundation/src/Windows1252Encoding.o contrib/poco/Foundation/src/Windows1252Encoding.cpp
 
 ${OBJECTDIR}/contrib/poco/Foundation/src/pcre_byte_order.o: contrib/poco/Foundation/src/pcre_byte_order.c
 	${MKDIR} -p ${OBJECTDIR}/contrib/poco/Foundation/src

--- a/nbproject/Makefile-impl.mk
+++ b/nbproject/Makefile-impl.mk
@@ -24,7 +24,7 @@ CLEAN_SUBPROJECTS=${CLEAN_SUBPROJECTS_${SUBPROJECTS}}
 
 
 # Project Name
-PROJECTNAME=PocoLithp
+PROJECTNAME=elispidae
 
 # Active Configuration
 DEFAULTCONF=Debug

--- a/nbproject/Makefile-variables.mk
+++ b/nbproject/Makefile-variables.mk
@@ -12,16 +12,16 @@ CND_ARTIFACT_DIR_Debug=bin
 CND_ARTIFACT_NAME_Debug=elisp
 CND_ARTIFACT_PATH_Debug=bin/elisp
 CND_PACKAGE_DIR_Debug=dist/Debug/GNU-Linux/package
-CND_PACKAGE_NAME_Debug=pocolithp.tar
-CND_PACKAGE_PATH_Debug=dist/Debug/GNU-Linux/package/pocolithp.tar
+CND_PACKAGE_NAME_Debug=elispidae.tar
+CND_PACKAGE_PATH_Debug=dist/Debug/GNU-Linux/package/elispidae.tar
 # Release configuration
 CND_PLATFORM_Release=GNU-Linux
 CND_ARTIFACT_DIR_Release=bin
 CND_ARTIFACT_NAME_Release=elisp
 CND_ARTIFACT_PATH_Release=bin/elisp
 CND_PACKAGE_DIR_Release=dist/Release/GNU-Linux/package
-CND_PACKAGE_NAME_Release=pocolithp.tar
-CND_PACKAGE_PATH_Release=dist/Release/GNU-Linux/package/pocolithp.tar
+CND_PACKAGE_NAME_Release=elispidae.tar
+CND_PACKAGE_PATH_Release=dist/Release/GNU-Linux/package/elispidae.tar
 #
 # include compiler specific variables
 #

--- a/nbproject/Package-Debug.bash
+++ b/nbproject/Package-Debug.bash
@@ -15,7 +15,7 @@ NBTMPDIR=${CND_BUILDDIR}/${CND_CONF}/${CND_PLATFORM}/tmp-packaging
 TMPDIRNAME=tmp-packaging
 OUTPUT_PATH=bin/elisp
 OUTPUT_BASENAME=elisp
-PACKAGE_TOP_DIR=pocolithp/
+PACKAGE_TOP_DIR=elispidae/
 
 # Functions
 function checkReturnCode
@@ -60,15 +60,15 @@ mkdir -p ${NBTMPDIR}
 
 # Copy files and create directories and links
 cd "${TOP}"
-makeDirectory "${NBTMPDIR}/pocolithp/bin"
+makeDirectory "${NBTMPDIR}/elispidae/bin"
 copyFileToTmpDir "${OUTPUT_PATH}" "${NBTMPDIR}/${PACKAGE_TOP_DIR}bin/${OUTPUT_BASENAME}" 0755
 
 
 # Generate tar file
 cd "${TOP}"
-rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/pocolithp.tar
+rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/elispidae.tar
 cd ${NBTMPDIR}
-tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/pocolithp.tar *
+tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/elispidae.tar *
 checkReturnCode
 
 # Cleanup

--- a/nbproject/Package-Release.bash
+++ b/nbproject/Package-Release.bash
@@ -15,7 +15,7 @@ NBTMPDIR=${CND_BUILDDIR}/${CND_CONF}/${CND_PLATFORM}/tmp-packaging
 TMPDIRNAME=tmp-packaging
 OUTPUT_PATH=bin/elisp
 OUTPUT_BASENAME=elisp
-PACKAGE_TOP_DIR=pocolithp/
+PACKAGE_TOP_DIR=elispidae/
 
 # Functions
 function checkReturnCode
@@ -60,15 +60,15 @@ mkdir -p ${NBTMPDIR}
 
 # Copy files and create directories and links
 cd "${TOP}"
-makeDirectory "${NBTMPDIR}/pocolithp/bin"
+makeDirectory "${NBTMPDIR}/elispidae/bin"
 copyFileToTmpDir "${OUTPUT_PATH}" "${NBTMPDIR}/${PACKAGE_TOP_DIR}bin/${OUTPUT_BASENAME}" 0755
 
 
 # Generate tar file
 cd "${TOP}"
-rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/pocolithp.tar
+rm -f ${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/elispidae.tar
 cd ${NBTMPDIR}
-tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/pocolithp.tar *
+tar -vcf ../../../../${CND_DISTDIR}/${CND_CONF}/${CND_PLATFORM}/package/elispidae.tar *
 checkReturnCode
 
 # Cleanup

--- a/nbproject/configurations.xml
+++ b/nbproject/configurations.xml
@@ -87,9 +87,15 @@
           <itemPath>contrib/poco/Foundation/src/pcre_xclass.c</itemPath>
         </logicalFolder>
       </logicalFolder>
+      <logicalFolder name="f1" displayName="stdlib" projectFiles="true">
+        <itemPath>PocoLithp/stdlib/ELdictionary.cpp</itemPath>
+        <itemPath>PocoLithp/stdlib/ELlists.cpp</itemPath>
+        <itemPath>PocoLithp/stdlib/ELstrings.cpp</itemPath>
+        <itemPath>PocoLithp/stdlib/ELthreads.cpp</itemPath>
+        <itemPath>PocoLithp/stdlib/PLglobals.cpp</itemPath>
+        <itemPath>PocoLithp/stdlib/stdafx.h</itemPath>
+      </logicalFolder>
       <itemPath>PocoLithp/ELisp.cpp</itemPath>
-      <itemPath>PocoLithp/ELthreads.cpp</itemPath>
-      <itemPath>PocoLithp/PLglobals.cpp</itemPath>
       <itemPath>PocoLithp/PLint_recursive.cpp</itemPath>
       <itemPath>PocoLithp/PLint_stackless.cpp</itemPath>
       <itemPath>PocoLithp/PLinterpreter.cpp</itemPath>
@@ -143,10 +149,6 @@
       </item>
       <item path="PocoLithp/ELisp.hpp" ex="false" tool="3" flavor2="0">
       </item>
-      <item path="PocoLithp/ELthreads.cpp" ex="false" tool="1" flavor2="0">
-      </item>
-      <item path="PocoLithp/PLglobals.cpp" ex="false" tool="1" flavor2="0">
-      </item>
       <item path="PocoLithp/PLint_recursive.cpp" ex="false" tool="1" flavor2="0">
       </item>
       <item path="PocoLithp/PLint_recursive.hpp" ex="false" tool="3" flavor2="0">
@@ -174,6 +176,18 @@
       <item path="PocoLithp/stdafx.cpp" ex="false" tool="1" flavor2="0">
       </item>
       <item path="PocoLithp/stdafx.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/ELdictionary.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/ELlists.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/ELstrings.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/ELthreads.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/PLglobals.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/stdafx.h" ex="false" tool="3" flavor2="0">
       </item>
       <item path="contrib/linenoise-ng/src/ConvertUTF.cpp"
             ex="false"
@@ -532,10 +546,6 @@
       </item>
       <item path="PocoLithp/ELisp.hpp" ex="false" tool="3" flavor2="0">
       </item>
-      <item path="PocoLithp/ELthreads.cpp" ex="false" tool="1" flavor2="0">
-      </item>
-      <item path="PocoLithp/PLglobals.cpp" ex="false" tool="1" flavor2="0">
-      </item>
       <item path="PocoLithp/PLint_recursive.cpp" ex="false" tool="1" flavor2="0">
       </item>
       <item path="PocoLithp/PLint_recursive.hpp" ex="false" tool="3" flavor2="0">
@@ -563,6 +573,18 @@
       <item path="PocoLithp/stdafx.cpp" ex="false" tool="1" flavor2="0">
       </item>
       <item path="PocoLithp/stdafx.h" ex="false" tool="3" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/ELdictionary.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/ELlists.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/ELstrings.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/ELthreads.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/PLglobals.cpp" ex="false" tool="1" flavor2="0">
+      </item>
+      <item path="PocoLithp/stdlib/stdafx.h" ex="false" tool="3" flavor2="0">
       </item>
       <item path="contrib/linenoise-ng/src/ConvertUTF.cpp"
             ex="false"

--- a/nbproject/private/configurations.xml
+++ b/nbproject/private/configurations.xml
@@ -13,8 +13,6 @@
         <gdb_interceptlist>
           <gdbinterceptoptions gdb_all="false" gdb_unhandled="true" gdb_unexpected="true"/>
         </gdb_interceptlist>
-        <gdb_signals>
-        </gdb_signals>
         <gdb_options>
           <DebugOptions>
           </DebugOptions>
@@ -48,8 +46,6 @@
         <gdb_interceptlist>
           <gdbinterceptoptions gdb_all="false" gdb_unhandled="true" gdb_unexpected="true"/>
         </gdb_interceptlist>
-        <gdb_signals>
-        </gdb_signals>
         <gdb_options>
           <DebugOptions>
           </DebugOptions>

--- a/samples/stress_threads.lisp
+++ b/samples/stress_threads.lisp
@@ -1,0 +1,75 @@
+;; This is part of the "stress testing" samples.
+;; It attempts to showcase simple thread spawning, waiting for messages,
+;; and sending replies.
+(begin
+
+	;; Number of threads to spawn - on or1k we spawn less threads
+	;; because it is a much slower platform.
+	(define ThreadCount
+		(if (== or1k (arch))
+			15
+			50
+		)
+	)
+	;; Uncomment for LOTS of debugging information
+	;; (debug true)
+
+	;; Helper function to spawn many threads with given Code and Argument.
+	;; Returns list of thread references.
+	(define spawn-many (# (Count Code Argument)
+		(+ (list (spawn Code Argument)) (if (> Count 0) (spawn-many (- Count 1) Code Argument) (list)))
+	))
+
+	;; Thread code, make it do something a little intensive
+	(define factorial (# (N) (fac2 N 1)))
+	(define fac2 (# (N A) (if (= N 0) A (fac2 (- N 1) (* N A)))))
+	(define ThreadCode (# (Parent) (begin
+		(print (self) "ready for request")
+		(receive
+			(# (Message) (begin
+				(print (self) "Received message: " Message)
+				(define MsgBody (head Message))
+				(define MsgSender (head (tail Message)))
+				(send (list complete MsgBody (factorial MsgBody)) MsgSender)
+			))
+			after 2000 (# () (begin
+				(print (self) "Timeout")
+			))
+		)
+		(print (self) "exiting")
+	)))
+	;; Master thread send/receive loop
+	(define message-loop (# (Threads N) (begin
+		(if (> (length Threads) 0)
+			;; Still have threads, send a request
+			(begin
+				(define Thread (head Threads))
+				(print "Requesting factorial " N "from" Thread)
+				(send (list N (self)) Thread)
+				(message-loop (tail Threads) (+ N 1))
+			)
+			;; else, sent messages to all threads, get responses.
+			;; we time out after 2s since we don't keep track of responses remaining.
+			(begin
+				(receive
+					(# (Message) (begin
+						(print "Got a response: " Message)
+						(message-loop (list) N)
+					))
+					after 2000 (# () (begin
+						(print "No message received after 2000ms")
+					))
+				)
+			)
+		)
+	)))
+
+	;; Spawn our threads
+	(define Threads (spawn-many ThreadCount ThreadCode (self)))
+	(print "Spawn many: " Threads)
+
+	;; Enter message loop
+	(message-loop Threads 2)
+
+	(print "Master thread exiting")
+)

--- a/samples/threading.lisp
+++ b/samples/threading.lisp
@@ -39,5 +39,32 @@
 		))
 	)
 
+	(define Thread1 (spawn (# (Parent) (begin
+		(print (self) " started with parent " Parent)
+		(define Message (list hello! (self)))
+		(send Message Parent)
+		(print (self) " waiting for response...")
+		(receive
+			(# (Message) (begin
+				(print (self) "Got response " Message)
+			))
+			after 2000 (# () (begin
+				(print (self) "Didn't get reply :(")
+			))
+		)
+		(print (self) " exiting")
+	)) Self))
+
+	(print (self) "Waiting for a message...")
+	(receive
+		(# (Message) (begin
+			(define MsgContent (head Message))
+			(define MsgSender (head (tail Message)))
+			(print (self) " got message: " MsgContent " from " MsgSender)
+			(define MsgReply hi!)
+			(print (self) " sending reply: " MsgReply)
+			(send MsgReply MsgSender)
+		))
+	)
 	(print "Master thread exiting")
 )

--- a/samples/threading.lisp
+++ b/samples/threading.lisp
@@ -27,26 +27,6 @@
 	(define Self (self))
 	(print "Master Thread" Self " started")
 
-	(define Thread1 (spawn (# (Parent) (begin
-		(print "Thread1 starting up, self=" (self) ", parent=" Parent)
-		(define Message (list (self) "sends its regards"))
-		(send Message Parent)
-		(print "Sent a message to " Parent)
-		(print "Thread1 waiting for reply")
-		(receive (# (Reply) (begin
-			(print "Thread1 got reply: " Reply)
-		)))
-		(print "Thread1 exiting")
-	)) Self))
-
-	(print "Master Thread: Waiting for message")
-	(receive (# (Message) (begin
-		(print (self) " got message: " Message)
-		(define ReplyAddress (head Message))
-		(print (self) " sending reply to " ReplyAddress)
-		(send acknowledged ReplyAddress)
-	)))
-
 	(print "Master Thread: Waiting for a message for 2s")
 	;; (print "BEING CHEEKY AND SENDING MYSELF A MESSAGE")
 	;; (send cheeky (self))
@@ -59,30 +39,5 @@
 		))
 	)
 
-	;; (debug true)
-	(define Thread2 (spawn (# (Parent) (begin
-		(print "Thread2 starting up, self=" (self) ", parent=" Parent)
-		(define Message (list (self) "sends its regards"))
-		(send Message Parent)
-		(print "Thread2 Sent a message to " Parent)
-		(print "Thread2 waiting for response...")
-		(receive (# (Response) (begin
-			(print "Got response:" Response)
-		)) after 1000 (# () (begin
-			(print "Thread2 failured to receive :|")
-		)))
-		(print "Thread2 exiting")
-	)) Self))
-	(receive
-		(# (Message) (begin
-			(print (self) " got message: " Message)
-			(define ReplyAddress (head Message))
-			(print (self) " sending reply to " ReplyAddress)
-			(send goodwork ReplyAddress)
-		))
-		after 2000 (# () (begin
-			(print (self) " timeout occurred, fail")
-		))
-	)
 	(print "Master thread exiting")
 )

--- a/samples/threading.lisp
+++ b/samples/threading.lisp
@@ -1,22 +1,31 @@
 ;; Microthreading example
+;;
+;; This example demonstrates:
+;;  o  Starting microthreads with arguments
+;;  o  Sending messages between microthreads
+;;  o  Waiting for messages before code execution continues
+;;  o  Callbacks for message wait timeouts
+;;
+;; Key types::
+;;  o  thread_ref()    A reference to a thread
+;; Key functions:
+;;  o  (send Message::any() Destination::thread_ref()) -> bool()
+;;     - (send "sending myself love" (self)) -> true
+;;     - (send "not around anymore" NonExistantThread) -> false
+;;  o  (spawn lambda(Args) Args::any()) -> thread_ref()
+;;     - (spawn (# () (print "Short lived thread"))) -> thread_ref()
+;;     - (spawn (# (Parent) (send short_lived Parent)) (self)) -> thread_ref()
+;;  o  (receive OnMessage::lambda(Message) timeout()) -> lambda::result
+;;     timeout() -> phrase 'infinity' |
+;;                  phrase 'after' Timeout::int() OnTimeout::lambda()
+;;     - (receive (# (Message) (print "Message:" Message))) -> nil
+;;     - (receive (# (Number) (+ 1 Number))) -> int()
+;;     - (receive (# (X Y) (+ X Y)) after 5000 (# () 0)) -> int()
 
 (begin
 
 	(define Self (self))
 	(print "Master Thread" Self " started")
-
-	;; A cheap appromixation of receive.
-	;; Actually, it's probably fairly CPU-intensive.
-	(define recv (# (OnMessage) (begin
-		;; Nice visualization of how message loop runs.
-		(print "(" (self) ".recv)")
-		(define Messages (flush (self) 1))
-		;; TODO: implement (empty List) check
-		(if (> (length Messages) 0)
-			(OnMessage (head Messages))
-			(recv OnMessage)
-		)
-	)))
 
 	(define Thread1 (spawn (# (Parent) (begin
 		(print "Thread1 starting up, self=" (self) ", parent=" Parent)
@@ -24,14 +33,14 @@
 		(send Message Parent)
 		(print "Sent a message to " Parent)
 		(print "Thread1 waiting for reply")
-		(recv (# (Reply) (begin
+		(receive (# (Reply) (begin
 			(print "Thread1 got reply: " Reply)
 		)))
 		(print "Thread1 exiting")
 	)) Self))
 
 	(print "Master Thread: Waiting for message")
-	(recv (# (Message) (begin
+	(receive (# (Message) (begin
 		(print (self) " got message: " Message)
 		(define ReplyAddress (head Message))
 		(print (self) " sending reply to " ReplyAddress)
@@ -45,7 +54,7 @@
 		(# (Message) (begin
 			(print (self) " got message when shouldnt: " Message)
 		))
-		after 20 (# () (begin
+		after 2000 (# () (begin
 			(print (self) " timeout occurred, success")
 		))
 	)


### PR DESCRIPTION
Complete rewrite of process management, message passing, macro handling.

Test cases pass, but currently issues in the standard library files (`lib/`) and samples.

- Everything now goes through `LithpProcessMan`
- Implements the basics of the Cosmos global node manager
- Implements single-threaded interpreter with option for later expansion
- Return values for macros are now executed immediately, conforming to standard Lisp behavior

Huge rewrite to Stackless process management.

Tested successfully on:
------------------------

* Visual Studio 2017
* GCC (x64, Linux)
* GCC (OR1K, Linux)
